### PR TITLE
Combine Export Tags Button and Selected Tags Counter to work together

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from calendar import monthcalendar
 import operator
 
+
 class DataManager:
     """Handles loading and managing data from JSON files"""
     
@@ -519,7 +520,7 @@ class DataManager:
         
         # Join with spaces
         return ' '.join(formatted_parts)
-    
+
 
 class UIHelper:
     """Helper class for common UI components and utilities"""
@@ -1207,7 +1208,7 @@ class AdvertiserTab:
         for checkbutton in self.tag_checkbuttons.values():
             checkbutton.grid()
     
-    def clear_selections(self):
+    def clear_selections(self, show_message: bool = True):
         """Clear all selected checkboxes across all tabs"""
         # Set all tag variables to False
         for tag_id, var in self.tag_vars.items():
@@ -1221,9 +1222,10 @@ class AdvertiserTab:
         self.selected_tags_text.config(state=tk.NORMAL)
         self.selected_tags_text.delete(1.0, tk.END)
         self.selected_tags_text.config(state=tk.DISABLED)
-        
-        # Show a message to confirm selections were cleared
-        messagebox.showinfo("Selections Cleared", "All story element selections have been cleared.")
+
+        if show_message:
+            # Show a message to confirm selections were cleared
+            messagebox.showinfo("Selections Cleared", "All story element selections have been cleared.")
     
     def calculate_weights(self):
         """Calculate audience weights based on selected tags."""
@@ -1410,6 +1412,12 @@ class AdvertiserTab:
         self.advertiser_text.config(state=tk.DISABLED)
         self.selected_tags_text.config(state=tk.DISABLED)
 
+    def select_tags(self, tags):
+        """ Select given tags """
+        for tag_id, var in self.tag_vars.items():
+            if tag_id in tags:
+                var.set(True)
+
 
 class CompatibilityTab:
     """Manages the Story Element Compatibility tab"""
@@ -1506,7 +1514,6 @@ class CompatibilityTab:
         # Build compatibility tag widgets in tabs
         self.build_compatibility_tag_widgets()
 
-        
         # Right frame - Compatibility Legend and Selected Tags
         ttk.Label(self.right_frame, text="Compatibility Legend", font=("Arial", 12, "bold")).grid(row=0, column=0, pady=5, sticky="w")
         
@@ -1537,6 +1544,10 @@ class CompatibilityTab:
             font=("Arial", 10, "bold")
         )
         self.score_display_label.pack(fill="both", expand=True)
+
+        # Button to export selected tags from CompatibilityTab to AdvertiserTab
+        self.export_to_advertiser_tab_button = ttk.Button(score_frame, text="Export to AdvertisersTab", command=self.export_to_advertisers_tab)
+        self.export_to_advertiser_tab_button.pack(side="left", padx=5)
         
         # Selected tags display
         ttk.Label(self.right_frame, text="Selected Tags:", font=("Arial", 10, "bold")).grid(row=3, column=0, sticky="w", pady=5)
@@ -1835,7 +1846,7 @@ class CompatibilityTab:
         
         # Show a message to confirm selections were cleared
         messagebox.showinfo("Selections Cleared", "All story element selections have been cleared.")
-    
+
     def update_compatibility_colors(self, changed_tag_id=None):
         """Update color indicators based on current tag selections and calculate average score"""
         # Get currently selected tags
@@ -2100,6 +2111,16 @@ class CompatibilityTab:
         close_button = ttk.Button(main_frame, text="Close", command=matrix_window.destroy)
         close_button.pack(pady=10)
 
+    def export_to_advertisers_tab(self):
+        """ Export all the selected tags from CompatibilityTab to AdvertiserTab """
+        # Get currently selected tags
+        selected_tags = [tag_id for tag_id, var in self.compat_tag_vars.items() if var.get()]
+
+        AdvertiserTab.clear_selections(app.advertiser_tab, False)
+        AdvertiserTab.select_tags(app.get_advertiser_tab(), selected_tags)
+        # Switch to AdvertiserTab
+        app.main_notebook.select(app.main_notebook.index(app.advertiser_tab_frame))
+
 
 class StoryElementCalculatorApp:
     """Main application class that coordinates all components"""
@@ -2152,6 +2173,9 @@ class StoryElementCalculatorApp:
         # Initialize the tab controllers
         self.advertiser_tab = AdvertiserTab(self.advertiser_tab_frame, self.data_manager, self.calculation_engine)
         self.compatibility_tab = CompatibilityTab(self.compatibility_tab_frame, self.data_manager)
+
+    def get_advertiser_tab(self):
+        return self.advertiser_tab
 
 
 if __name__ == "__main__":

--- a/gui.py
+++ b/gui.py
@@ -1,5 +1,6 @@
 import json
 import tkinter as tk
+import typing
 from tkinter import ttk, messagebox, scrolledtext
 import os
 import re
@@ -890,7 +891,7 @@ class CalculationEngine:
 
 class AdvertiserTab:
     """Manages the Advertiser Compatibility tab"""
-    
+
     def __init__(self, parent, data_manager, calculation_engine):
         self.parent = parent
         self.data_manager = data_manager
@@ -1235,9 +1236,6 @@ class AdvertiserTab:
         if show_message:
             # Show a message to confirm selections were cleared
             messagebox.showinfo("Selections Cleared", "All story element selections have been cleared.")
-        
-        # Show a message to confirm selections were cleared
-        messagebox.showinfo("Selections Cleared", "All story element selections have been cleared.")
 
         self.tags_counter.reset()
     
@@ -1431,6 +1429,7 @@ class AdvertiserTab:
         for tag_id, var in self.tag_vars.items():
             if tag_id in tags:
                 var.set(True)
+
     def on_cb_click(self, tag_id, var):
         self.tags_counter.update(tag_id, var)
 
@@ -1870,7 +1869,6 @@ class CompatibilityTab:
         messagebox.showinfo("Selections Cleared", "All story element selections have been cleared.")
 
         self.tags_counter.reset()
-    
 
     def update_compatibility_colors(self, changed_tag_id=None):
         """Update color indicators based on current tag selections and calculate average score"""
@@ -2141,8 +2139,11 @@ class CompatibilityTab:
         # Get currently selected tags
         selected_tags = [tag_id for tag_id, var in self.compat_tag_vars.items() if var.get()]
 
-        AdvertiserTab.clear_selections(app.advertiser_tab, False)
-        AdvertiserTab.select_tags(app.get_advertiser_tab(), selected_tags)
+        app.advertiser_tab.clear_selections(False)
+        app.advertiser_tab.select_tags(selected_tags)
+        app.advertiser_tab.tags_counter.tags_count = self.tags_counter.tags_count
+        app.advertiser_tab.tags_counter.update()
+
         # Switch to AdvertiserTab
         app.main_notebook.select(app.main_notebook.index(app.advertiser_tab_frame))
 
@@ -2153,7 +2154,7 @@ class CompatibilityTab:
 
 class StoryElementCalculatorApp:
     """Main application class that coordinates all components"""
-    
+
     def __init__(self, root):
         self.root = root
         self.root.title("Hollywood Animal Calculator")
@@ -2203,9 +2204,6 @@ class StoryElementCalculatorApp:
         self.advertiser_tab = AdvertiserTab(self.advertiser_tab_frame, self.data_manager, self.calculation_engine)
         self.compatibility_tab = CompatibilityTab(self.compatibility_tab_frame, self.data_manager)
 
-    def get_advertiser_tab(self):
-        return self.advertiser_tab
-
 
 class TagsCounter:
     def __init__(self, tab):
@@ -2216,7 +2214,12 @@ class TagsCounter:
         self.tags_count = 0
         self.tab.counter_label.config(text="Story Elements Count: " + str(self.tags_count))
 
-    def update(self, tag_id, var):
+    def update(self, tag_id=None, var=None):
+        # Updates label without clicking checkbox
+        if tag_id is None or var is None:
+            self.tab.counter_label.config(text="Story Elements Count: " + str(self.tags_count))
+            return
+
         # Check if the selected tag is in Genre or Setting category and don't count it
         if tag_id in self.tab.data_manager.genre_tags or tag_id in self.tab.data_manager.setting_tags:
             return


### PR DESCRIPTION
**This PR combines the Export Tags Button and the Selected Tags Counter so they work together.**

![image](https://github.com/user-attachments/assets/0d2cd076-7895-4e97-82dc-097e2fc5292f)
![image](https://github.com/user-attachments/assets/047439a4-9334-4aac-904e-e1b871e81611)


Previously, both features worked independently, but when used together, the counter wouldn’t update correctly after exporting. This integration ensures the counter stays accurate and in sync with any tag selection changes triggered by the export.

Both features are still submitted separately in their own pull requests. This branch is provided as an option in case the combined functionality is preferred and easier to review or merge.